### PR TITLE
Fix CSS path in Sudoku page

### DIFF
--- a/Dashboard/html/sudoku.html
+++ b/Dashboard/html/sudoku.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../css/base.css">
     <link rel="stylesheet" href="../css/responsive.css">
     <link rel="stylesheet" href="../css/themes/crt-theme.css" id="theme-stylesheet">
-    <link rel="stylesheet" href="../css/sudoku/sudoku.css">
+    <link rel="stylesheet" href="../css/sudoku.css">
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- point Sudoku page to the correct CSS file

## Testing
- `npx --yes htmlhint Dashboard/html/sudoku.html`

------
https://chatgpt.com/codex/tasks/task_e_688280e7e09c8331b50c36ce87d1fdbe