### PR TITLE
Fix dashboard path references

### DIFF
--- a/Dashboard/html/dashboard.html
+++ b/Dashboard/html/dashboard.html
@@ -6,12 +6,12 @@
   <title>Daily Dashboard</title>
 
   <!-- Base & Theme Styles -->
-  <link rel="stylesheet" href="../base.css">
+  <link rel="stylesheet" href="../css/base.css">
     <!-- Page Specific -->
-  <link rel="stylesheet" href="dashboard.css">
+  <link rel="stylesheet" href="../css/dashboard.css">
   
-  <link rel="stylesheet" href="../responsive.css">
-  <link rel="stylesheet" href="../crt-theme.css" id="theme-stylesheet">
+  <link rel="stylesheet" href="../css/responsive.css">
+  <link rel="stylesheet" href="../css/themes/crt-theme.css" id="theme-stylesheet">
 
 
 </head>
@@ -85,7 +85,7 @@
   </div> <!-- End of widget-container -->
 
   <!-- Scripts -->
-  <script src="../base.js"></script>
-  <script src="dashboard.js" defer></script>
+  <script src="../js/base.js"></script>
+  <script src="../js/dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct paths to CSS and JS resources in dashboard.html

## Testing
- `grep -n '<script' Dashboard/html/dashboard.html`

------
https://chatgpt.com/codex/tasks/task_e_688280e16ad48331a8c3579c963332bd